### PR TITLE
Important Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "devDependencies": {
     "grunt": "~0.4.*",
-    "grunt-browserify": "~10.*.*",
+    "grunt-browserify": "~3.8.*",
     "grunt-contrib-jshint": "~0.11.*",
     "grunt-jscs": "~1.6.*",
     "nodeunit": "0.9.*"


### PR DESCRIPTION
Error in package.json.
grunt-browserify Version : 
Note: While the current version of browserify is 10.2.3 we need the version for the grunt plugin.
The current version of grunt-browserify is 3.8.0 ...