### PR TITLE
Add main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "nlp_compromise",
   "description": "natural language processing in the browser",
   "version": "2.0.0",
+  "main": "src/index.js",
   "date": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently to use `nlp_compromise` in a node style env (e.g. webpack, browserify, node) it's required specify the full path. 

e.g. 
```
import nlp from "nlp_compromise/src/index"
```

Add the `main` entry in the package.json allow to use just
so that we can just do

```
import nlp from "nlp_compromise"
```